### PR TITLE
GTM Id and OneTrust disabled until Go-Live

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -14,18 +14,18 @@ const isPerformanceAllowed = cookieSetting.includes(COOKIES.performance);
 
 if (isPerformanceAllowed) {
   loadGoogleTagManager();
-  loadHotjar();
 }
 
 // add more delayed functionality here
 
+/* Commented until the site is live --->
 // Prevent the cookie banner from loading when running in library
 if (!window.location.pathname.includes('srcdoc')
   && !['localhost', 'hlx.page'].some((url) => window.location.host.includes(url))) {
   loadScript('https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', {
     type: 'text/javascript',
     charset: 'UTF-8',
-    'data-domain-script': 'bf50d0a6-e209-4fd4-ad2c-17da5f9e66a5',
+    'data-domain-script': 'bf50d0a6-e209-4fd4-ad2c-17da5f9e66a5', // ID?
   });
 }
 
@@ -46,6 +46,7 @@ window.OptanonWrapper = () => {
     }
   });
 };
+<--- */
 
 // Google Analytics
 async function loadGoogleTagManager() {
@@ -54,17 +55,5 @@ async function loadGoogleTagManager() {
   (function (w, d, s, l, i) {
     w[l] = w[l] || []; w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' }); const f = d.getElementsByTagName(s)[0]; const j = d.createElement(s); const
       dl = l !== 'dataLayer' ? `&l=${l}` : ''; j.async = true; j.src = `https://www.googletagmanager.com/gtm.js?id=${i}${dl}`; f.parentNode.insertBefore(j, f);
-  }(window, document, 'script', 'dataLayer', 'GTM-NDMV8BN'));
-}
-
-// Hotjar
-async function loadHotjar() {
-  /* eslint-disable */
-  (function(h,o,t,j,a,r){
-    h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-    h._hjSettings={hjid:597204,hjsv:6}; a=o.getElementsByTagName('head')[0];
-    r=o.createElement('script');r.async=1; r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-    a.appendChild(r);
-  })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-  /* eslint-enable */
+  }(window, document, 'script', 'dataLayer', 'GTM-5DKKVHFL'));
 }


### PR DESCRIPTION
# Update

All the related code of OneTrust has been disabled, but the GTM is still active under performance cookie

#

### Fix #8

Test URLs:
- Before: https://main--vg-macktrucks-sv--hlxsites.hlx.page/
- After: https://8-configure-analytics-tracking--vg-macktrucks-sv--hlxsites.hlx.page/
