### PR TITLE
676 step 1: add OT ID & add constants.js

### DIFF
--- a/blocks/eloqua-form/eloqua-form.js
+++ b/blocks/eloqua-form/eloqua-form.js
@@ -1,5 +1,5 @@
 import { loadScriptIfNotLoadedYet } from '../../scripts/scripts.js';
-import { createElement, getTextLabel, isEloquaFormAllowed } from '../../scripts/common.js';
+import { createElement, getTextLabel, isTargetingAllowed } from '../../scripts/common.js';
 
 // Every eloqua form has it's own JS, CSS and HTML.
 // Once the form is loaded all the JS and CSS are added to the body.
@@ -169,7 +169,7 @@ const addNoCookieMessage = (messageContainer) => {
 export default async function decorate(block) {
   const observer = new IntersectionObserver((entries) => {
     if (entries.some((e) => e.isIntersecting)) {
-      if (!isEloquaFormAllowed()) {
+      if (!isTargetingAllowed()) {
         addNoCookieMessage(block);
 
         return;

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -5,7 +5,7 @@ import {
   getMetadata,
 } from '../../scripts/lib-franklin.js';
 import {
-  createElement, getTextLabel, isEloquaFormAllowed,
+  createElement, getTextLabel, isTargetingAllowed,
 } from '../../scripts/common.js';
 
 const PLACEHOLDERS = {
@@ -212,7 +212,7 @@ export default async function decorate(block) {
   await loadBlocks(block);
 
   const onFormLoaded = (mutationList) => {
-    if (!isEloquaFormAllowed()) {
+    if (!isTargetingAllowed()) {
       return;
     }
 

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -6,7 +6,9 @@ import {
   loadHeader,
   loadFooter,
 } from './lib-franklin.js';
+import { COOKIE_VALUES, COOKIE_CHECK } from './constants.js';
 
+const { performance, targeting, social } = COOKIE_VALUES;
 let placeholders = null;
 
 export async function getPlaceholders() {
@@ -116,8 +118,8 @@ export async function loadLazy(doc) {
  * the user experience.
  */
 export function loadDelayed() {
-  // eslint-disable-next-line import/no-cycle
   window.setTimeout(() => {
+    // eslint-disable-next-line import/no-cycle
     import('./delayed.js');
   }, 3000);
   // load anything that can be postponed to the latest here
@@ -181,13 +183,21 @@ export const slugify = (text) => (
  * Check if one trust group is checked.
  * @param {String} groupName the one trust croup like: C0002
  */
-export function checkOneTruckGroup(groupName) {
+export function checkOneTrustGroup(groupName, cookieCheck = false) {
   const oneTrustCookie = decodeURIComponent(document.cookie.split(';').find((cookie) => cookie.trim().startsWith('OptanonConsent=')));
-  return oneTrustCookie.includes(`${groupName}:1`);
+  return cookieCheck || oneTrustCookie.includes(`${groupName}:1`);
 }
 
-export function isEloquaFormAllowed() {
-  return checkOneTruckGroup('C0004');
+export function isPerformanceAllowed() {
+  return checkOneTrustGroup(performance, COOKIE_CHECK);
+}
+
+export function isTargetingAllowed() {
+  return checkOneTrustGroup(targeting, COOKIE_CHECK);
+}
+
+export function isSocialAllowed() {
+  return checkOneTrustGroup(social, COOKIE_CHECK);
 }
 
 /**

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,0 +1,15 @@
+// check if an active campaign is running or OneTrust needs scan the active scripts
+export const COOKIE_CHECK = true;
+
+// ONE TRUST COOKIE CONSENT
+export const DATA_DOMAIN_SCRIPT = 'f32a5898-5d20-4ec9-8ce7-20702edd7c2f';
+
+// GOOGLE TAG MANAGER ID
+export const GTM_ID = 'GTM-5DKKVHFL';
+
+// COOKIE Constants
+export const COOKIE_VALUES = {
+  performance: 'C0002',
+  targeting: 'C0004',
+  social: 'C0005',
+};

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,31 +1,28 @@
 // eslint-disable-next-line import/no-cycle
 import { sampleRUM, loadScript } from './lib-franklin.js';
-
-const COOKIES = {
-  performance: 'C0002:1',
-};
+import { isPerformanceAllowed } from './common.js';
+import {
+  DATA_DOMAIN_SCRIPT,
+  GTM_ID,
+} from './constants.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
-const cookieSetting = decodeURIComponent(document.cookie.split(';')
-  .find((cookie) => cookie.trim().startsWith('OptanonConsent=')));
-const isPerformanceAllowed = cookieSetting.includes(COOKIES.performance);
-
-if (isPerformanceAllowed) {
+// COOKIE ACCEPTANCE CHECKING
+if (isPerformanceAllowed()) {
   loadGoogleTagManager();
 }
 
 // add more delayed functionality here
 
-/* Commented until the site is live --->
 // Prevent the cookie banner from loading when running in library
 if (!window.location.pathname.includes('srcdoc')
   && !['localhost', 'hlx.page'].some((url) => window.location.host.includes(url))) {
   loadScript('https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', {
     type: 'text/javascript',
     charset: 'UTF-8',
-    'data-domain-script': 'bf50d0a6-e209-4fd4-ad2c-17da5f9e66a5', // ID?
+    'data-domain-script': DATA_DOMAIN_SCRIPT,
   });
 }
 
@@ -46,7 +43,7 @@ window.OptanonWrapper = () => {
     }
   });
 };
-<--- */
+
 
 // Google Analytics
 async function loadGoogleTagManager() {
@@ -55,5 +52,5 @@ async function loadGoogleTagManager() {
   (function (w, d, s, l, i) {
     w[l] = w[l] || []; w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' }); const f = d.getElementsByTagName(s)[0]; const j = d.createElement(s); const
       dl = l !== 'dataLayer' ? `&l=${l}` : ''; j.async = true; j.src = `https://www.googletagmanager.com/gtm.js?id=${i}${dl}`; f.parentNode.insertBefore(j, f);
-  }(window, document, 'script', 'dataLayer', 'GTM-5DKKVHFL'));
+  }(window, document, 'script', 'dataLayer', GTM_ID));
 }

--- a/test/scripts/common.test.js
+++ b/test/scripts/common.test.js
@@ -130,12 +130,12 @@ describe('slugify', () => {
   });
 });
 
-describe('checkOneTruckGroup', () => {
+describe('checkOneTrustGroup', () => {
   it('should return true when the group is present with value 1', () => {
     // Simulate a cookie with the group 'group1' set to 1
     document.cookie = 'OptanonConsent=group1:1;';
 
-    const result = commonScript.checkOneTruckGroup('group1');
+    const result = commonScript.checkOneTrustGroup('group1');
     expect(result).to.be.true;
   });
 
@@ -143,7 +143,7 @@ describe('checkOneTruckGroup', () => {
     // Simulate a cookie with the group 'group2' set to 0 (or any value other than 1)
     document.cookie = 'OptanonConsent=group2:0;';
 
-    const result = commonScript.checkOneTruckGroup('group2');
+    const result = commonScript.checkOneTrustGroup('group2');
     expect(result).to.be.false;
   });
 
@@ -151,7 +151,7 @@ describe('checkOneTruckGroup', () => {
     // Simulate an empty cookie
     document.cookie = '';
 
-    const result = commonScript.checkOneTruckGroup('group3');
+    const result = commonScript.checkOneTrustGroup('group3');
     expect(result).to.be.false;
   });
 
@@ -159,7 +159,7 @@ describe('checkOneTruckGroup', () => {
     // Simulate a cookie with a URL-encoded group name
     document.cookie = 'OptanonConsent=group%204:1;';
 
-    const result = commonScript.checkOneTruckGroup('group 4');
+    const result = commonScript.checkOneTrustGroup('group 4');
     expect(result).to.be.true;
   });
 });


### PR DESCRIPTION
### Step 1

- add `constants.js` to save delayed scripts IDs
- update `common.js` with the last updates, like the other already updated markets
- also update the function name in `common.test.js`
- uncomment the OneTrust code in `delayed.js` and also update this file to handle the constants in the IDs
- check `footer.js` to be sure that the _null at footer_ is also fixed

#

Fix [676](https://github.com/hlxsites/vg-macktrucks-com/issues/676)

Test URLs:
- Before: https://main--vg-macktrucks-sv--hlxsites.hlx.page/
- After: https://676-missing-ot-id--vg-macktrucks-sv--hlxsites.hlx.page/
